### PR TITLE
Fix iOS 14 IAP

### DIFF
--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -335,7 +335,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTPromiseResolveBlock)resolve
 
 - (NSDictionary *)RCTJSTransactionFromSKPaymentTransaction:(SKPaymentTransaction *)transaction withAppReceipt:(NSData *)appReceipt {
     NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithDictionary: @{
-        @"transactionState": transaction.transactionState ? [self RCTJSStringFromTransactionState:transaction.transactionState] : @"UNKNOWN",
+        @"transactionState": [self RCTJSStringFromTransactionState:transaction.transactionState],
         @"transactionDate": transaction.transactionDate ? @(transaction.transactionDate.timeIntervalSince1970 * 1000) : [NSNumber numberWithInt:0],
         @"transactionIdentifier": transaction.transactionIdentifier ? transaction.transactionIdentifier : @"",
         @"productIdentifier": transaction.payment.productIdentifier,


### PR DESCRIPTION
Ok the following happened:
→ User wants to buy premium → STATE: "purchasing"
→ State comes from the SKPaymentTransactionState enum →  SKPaymentTransactionStatePurchasing maps to 0
→ 0 is falsy → "UNKNOWN" is returned to JS, which fails our JS code because we think an error occurred.

Fixed it by removing the check altogether, why: transactionState cannot be nil according to the documentation hence it will always have a value. The code that maps the value to a JS string does not compile if a new value is added so the check doesn't make sense.

@ronaldsteen I don't think Joep has access to this repo, I cannot select him for review.