### PR TITLE
Make SKProductDiscount available in JS

### DIFF
--- a/InAppUtils.xcodeproj/project.pbxproj
+++ b/InAppUtils.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		46E694381B289730000B634E /* InAppUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 46E694371B289730000B634E /* InAppUtils.m */; };
 		46E6943E1B289730000B634E /* libInAppUtils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 46E694321B289730000B634E /* libInAppUtils.a */; };
 		46E694841B28E42F000B634E /* SKProduct+StringPrice.m in Sources */ = {isa = PBXBuildFile; fileRef = 46E694831B28E42F000B634E /* SKProduct+StringPrice.m */; };
+		C724ED0E25E7C8B30075F4F9 /* SKProductDiscount+StringPrice.m in Sources */ = {isa = PBXBuildFile; fileRef = C724ED0C25E7C8B30075F4F9 /* SKProductDiscount+StringPrice.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +45,8 @@
 		46E694431B289730000B634E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		46E694821B28E404000B634E /* SKProduct+StringPrice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SKProduct+StringPrice.h"; sourceTree = "<group>"; };
 		46E694831B28E42F000B634E /* SKProduct+StringPrice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SKProduct+StringPrice.m"; sourceTree = "<group>"; };
+		C724ED0C25E7C8B30075F4F9 /* SKProductDiscount+StringPrice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SKProductDiscount+StringPrice.m"; sourceTree = "<group>"; };
+		C724ED0D25E7C8B30075F4F9 /* SKProductDiscount+StringPrice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SKProductDiscount+StringPrice.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,6 +89,8 @@
 		46E694341B289730000B634E /* InAppUtils */ = {
 			isa = PBXGroup;
 			children = (
+				C724ED0D25E7C8B30075F4F9 /* SKProductDiscount+StringPrice.h */,
+				C724ED0C25E7C8B30075F4F9 /* SKProductDiscount+StringPrice.m */,
 				46E694351B289730000B634E /* InAppUtils.h */,
 				46E694371B289730000B634E /* InAppUtils.m */,
 				46E694821B28E404000B634E /* SKProduct+StringPrice.h */,
@@ -170,6 +175,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 46E694291B289730000B634E;
@@ -198,6 +204,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C724ED0E25E7C8B30075F4F9 /* SKProductDiscount+StringPrice.m in Sources */,
 				46E694841B28E42F000B634E /* SKProduct+StringPrice.m in Sources */,
 				46E694381B289730000B634E /* InAppUtils.m in Sources */,
 			);

--- a/InAppUtils/SKProductDiscount+StringPrice.h
+++ b/InAppUtils/SKProductDiscount+StringPrice.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+
+@interface SKProductDiscount (StringPrice)
+
+@property (nonatomic, readonly) NSString *priceString;
+
+@end

--- a/InAppUtils/SKProductDiscount+StringPrice.m
+++ b/InAppUtils/SKProductDiscount+StringPrice.m
@@ -1,0 +1,15 @@
+#import "SKProductDiscount+StringPrice.h"
+
+
+@implementation SKProductDiscount (StringPrice)
+
+- (NSString *)priceString {
+    NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+    formatter.formatterBehavior = NSNumberFormatterBehavior10_4;
+    formatter.numberStyle = NSNumberFormatterCurrencyStyle;
+    formatter.locale = self.priceLocale;
+
+    return [formatter stringFromNumber:self.price];
+}
+
+@end


### PR DESCRIPTION
This makes SKProductDiscount available in JS → `introductoryPrice` contains anything that has a discount (including free trial). You can use the `paymentMode` property to distinguish between free trial and a real discount.